### PR TITLE
Dynamic loading for D3D12 device and DXGI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/d3d12"
 categories = ["memory-management"]
 
+[features]
+libstatic = []
+
 [dependencies]
 bitflags = "1"
+libloading = { version = "0.5", optional = true }
 
 [dependencies.winapi]
 version = "0.3"
-features = ["dxgi1_2","dxgi1_3","dxgi1_4","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
+features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,6 @@ install:
 build: false
 test_script:
   - cargo check
+  - cargo check --features libloading
+  - cargo check --features libstatic
+  - cargo check --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,3 +83,8 @@ impl Error {
         CStr::from_ptr(data as *const _ as *const _)
     }
 }
+
+#[cfg(feature = "libloading")]
+pub struct D3D12Lib {
+    lib: libloading::Library,
+}


### PR DESCRIPTION
Fixes #18

Users can opt into static/implicit linking, or explicit one with "libloading", or even both (to make features truly additive).
I believe these changes cover the entry points we need to get everything running on any other Windows than 10.