### PR TITLE
Preparations for 0.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "d3d12"
-version = "0.2.2"
-authors = ["msiglreith <m.siglreith@gmail.com>"]
+version = "0.3.0"
+authors = [
+	"msiglreith <m.siglreith@gmail.com>",
+	"Dzmitry Malyshau <kvarkus@gmail.com>",
+]
 description = "Low level D3D12 API wrapper"
 repository = "https://github.com/gfx-rs/d3d12-rs"
 keywords = ["windows", "graphics"]
@@ -10,7 +13,7 @@ documentation = "https://docs.rs/d3d12"
 categories = ["memory-management"]
 
 [features]
-libstatic = []
+implicit-link = []
 
 [dependencies]
 bitflags = "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ build: false
 test_script:
   - cargo check
   - cargo check --features libloading
-  - cargo check --features libstatic
+  - cargo check --features implicit-link
   - cargo check --all-features

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,5 @@
 use com::WeakPtr;
-#[cfg(any(feature = "libloading", feature = "libstatic"))]
+#[cfg(any(feature = "libloading", feature = "implicit-link"))]
 use winapi::Interface as _;
 use winapi::um::d3d12sdklayers;
 
@@ -27,7 +27,7 @@ impl crate::D3D12Lib {
 }
 
 impl Debug {
-    #[cfg(feature = "libstatic")]
+    #[cfg(feature = "implicit-link")]
     pub fn get_interface() -> crate::D3DResult<Self> {
         let mut debug = Debug::null();
         let hr = unsafe {

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -245,7 +245,7 @@ impl crate::D3D12Lib {
 }
 
 impl RootSignature {
-    #[cfg(feature = "libstatic")]
+    #[cfg(feature = "implicit-link")]
     pub fn serialize(
         version: RootSignatureVersion,
         parameters: &[RootParameter],

--- a/src/device.rs
+++ b/src/device.rs
@@ -46,7 +46,7 @@ impl crate::D3D12Lib {
 }
 
 impl Device {
-    #[cfg(feature = "libstatic")]
+    #[cfg(feature = "implicit-link")]
     pub fn create<I: Interface>(
         adapter: WeakPtr<I>,
         feature_level: crate::FeatureLevel,

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -48,6 +48,7 @@ pub type SwapChain1 = WeakPtr<dxgi1_2::IDXGISwapChain1>;
 pub type SwapChain3 = WeakPtr<dxgi1_4::IDXGISwapChain3>;
 
 #[cfg(feature = "libloading")]
+#[derive(Debug)]
 pub struct DxgiLib {
     lib: libloading::Library,
 }
@@ -160,7 +161,7 @@ impl Factory2 {
 }
 
 impl Factory4 {
-    #[cfg(feature = "libstatic")]
+    #[cfg(feature = "implicit-link")]
     pub fn create(flags: FactoryCreationFlags) -> D3DResult<Self> {
         let mut factory = Factory4::null();
         let hr = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,17 @@ impl Error {
 }
 
 #[cfg(feature = "libloading")]
+#[derive(Debug)]
 pub struct D3D12Lib {
     lib: libloading::Library,
+}
+
+#[cfg(feature = "libloading")]
+impl D3D12Lib {
+    pub fn new() -> libloading::Result<Self> {
+        libloading::Library::new("d3d12.dll")
+            .map(|lib| D3D12Lib {
+                lib,
+            })
+    }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -13,8 +13,6 @@ pub struct DiscardRegion<'a> {
     pub subregions: Range<Subresource>,
 }
 
-pub type Heap = WeakPtr<d3d12::ID3D12Heap>;
-
 pub type Resource = WeakPtr<d3d12::ID3D12Resource>;
 
 impl Resource {


### PR DESCRIPTION
Including:
- rename feature "libstatic" to "implicit-link"
- Debug and constructor implementations for the library structs
- removal of redundant Heap definition