### PR TITLE
Use windows as default doc target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ libloading = { version = "0.5", optional = true }
 [dependencies.winapi]
 version = "0.3"
 features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Relates to https://github.com/gfx-rs/d3d12-rs/issues/15, not sure if it fully fixes it