### PR TITLE
Bump libloading to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ implicit-link = []
 
 [dependencies]
 bitflags = "1"
-libloading = { version = "0.5", optional = true }
+libloading = { version = "0.6", optional = true }
 
 [dependencies.winapi]
 version = "0.3"

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,7 +7,7 @@ pub type Debug = WeakPtr<d3d12sdklayers::ID3D12Debug>;
 
 #[cfg(feature = "libloading")]
 impl crate::D3D12Lib {
-    pub fn get_debug_interface(&self) -> libloading::Result<crate::D3DResult<Debug>> {
+    pub fn get_debug_interface(&self) -> Result<crate::D3DResult<Debug>, libloading::Error> {
         type Fun = extern "system" fn(
             winapi::shared::guiddef::REFIID,
             *mut *mut winapi::ctypes::c_void,

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -211,7 +211,7 @@ impl crate::D3D12Lib {
         parameters: &[RootParameter],
         static_samplers: &[StaticSampler],
         flags: RootSignatureFlags,
-    ) -> libloading::Result<BlobResult> {
+    ) -> Result<BlobResult, libloading::Error> {
         use winapi::um::d3dcommon::ID3DBlob;
         type Fun = extern "system" fn(
             *const d3d12::D3D12_ROOT_SIGNATURE_DESC,

--- a/src/device.rs
+++ b/src/device.rs
@@ -22,7 +22,7 @@ impl crate::D3D12Lib {
         &self,
         adapter: WeakPtr<I>,
         feature_level: crate::FeatureLevel,
-    ) -> libloading::Result<D3DResult<Device>> {
+    ) -> Result<D3DResult<Device>, libloading::Error> {
         type Fun = extern "system" fn(
             *mut winapi::um::unknwnbase::IUnknown,
             winapi::um::d3dcommon::D3D_FEATURE_LEVEL,

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -55,7 +55,7 @@ pub struct DxgiLib {
 
 #[cfg(feature = "libloading")]
 impl DxgiLib {
-    pub fn new() -> libloading::Result<Self> {
+    pub fn new() -> Result<Self, libloading::Error> {
         libloading::Library::new("dxgi.dll")
             .map(|lib| DxgiLib {
                 lib,
@@ -64,7 +64,7 @@ impl DxgiLib {
 
     pub fn create_factory2(
         &self, flags: FactoryCreationFlags
-    ) -> libloading::Result<D3DResult<Factory4>> {
+    ) -> Result<D3DResult<Factory4>, libloading::Error> {
         type Fun = extern "system" fn(
             winapi::shared::minwindef::UINT,
             winapi::shared::guiddef::REFIID,
@@ -84,7 +84,7 @@ impl DxgiLib {
         Ok((factory, hr))
     }
 
-    pub fn get_debug_interface1(&self) -> libloading::Result<D3DResult<InfoQueue>> {
+    pub fn get_debug_interface1(&self) -> Result<D3DResult<InfoQueue>, libloading::Error> {
         type Fun = extern "system" fn(
             winapi::shared::minwindef::UINT,
             winapi::shared::guiddef::REFIID,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub struct D3D12Lib {
 
 #[cfg(feature = "libloading")]
 impl D3D12Lib {
-    pub fn new() -> libloading::Result<Self> {
+    pub fn new() -> Result<Self, libloading::Error> {
         libloading::Library::new("d3d12.dll")
             .map(|lib| D3D12Lib {
                 lib,


### PR DESCRIPTION
They got rid of their typedef for their result type. Strange.

Breaking change, so can't go out in a patch release.