### PR TITLE
Add present flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d3d12"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
 	"msiglreith <m.siglreith@gmail.com>",
 	"Dzmitry Malyshau <kvarkus@gmail.com>",

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     com::WeakPtr, resource::DiscardRegion, CommandAllocator, CpuDescriptor, DescriptorHeap, Format,
-    GpuAddress, GpuDescriptor, IndexCount, InstanceCount, PipelineState, Rect, Resource,
-    RootSignature, VertexCount, VertexOffset, WorkGroupCount, HRESULT,
+    GpuAddress, GpuDescriptor, IndexCount, InstanceCount, PipelineState, Rect, Resource, RootIndex,
+    RootSignature, Subresource, VertexCount, VertexOffset, WorkGroupCount, HRESULT,
 };
 use std::{mem, ptr};
 use winapi::um::d3d12;
@@ -60,7 +60,7 @@ pub struct ResourceBarrier(d3d12::D3D12_RESOURCE_BARRIER);
 impl ResourceBarrier {
     pub fn transition(
         resource: Resource,
-        subresource: u32,
+        subresource: Subresource,
         state_before: d3d12::D3D12_RESOURCE_STATES,
         state_after: d3d12::D3D12_RESOURCE_STATES,
         flags: d3d12::D3D12_RESOURCE_BARRIER_FLAGS,
@@ -183,13 +183,13 @@ impl GraphicsCommandList {
     }
 
     pub fn set_index_buffer(&self, gpu_address: GpuAddress, size: u32, format: Format) {
-        let mut ibv = d3d12::D3D12_INDEX_BUFFER_VIEW {
+        let ibv = d3d12::D3D12_INDEX_BUFFER_VIEW {
             BufferLocation: gpu_address,
             SizeInBytes: size,
             Format: format,
         };
         unsafe {
-            self.IASetIndexBuffer(&mut ibv);
+            self.IASetIndexBuffer(&ibv);
         }
     }
 
@@ -240,7 +240,7 @@ impl GraphicsCommandList {
 
     pub fn set_compute_root_descriptor_table(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         base_descriptor: GpuDescriptor,
     ) {
         unsafe {
@@ -250,7 +250,7 @@ impl GraphicsCommandList {
 
     pub fn set_compute_root_constant_buffer_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {
@@ -260,7 +260,7 @@ impl GraphicsCommandList {
 
     pub fn set_compute_root_shader_resource_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {
@@ -270,7 +270,7 @@ impl GraphicsCommandList {
 
     pub fn set_compute_root_unordered_access_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {
@@ -280,7 +280,7 @@ impl GraphicsCommandList {
 
     pub fn set_graphics_root_descriptor_table(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         base_descriptor: GpuDescriptor,
     ) {
         unsafe {
@@ -290,7 +290,7 @@ impl GraphicsCommandList {
 
     pub fn set_graphics_root_constant_buffer_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {
@@ -300,7 +300,7 @@ impl GraphicsCommandList {
 
     pub fn set_graphics_root_shader_resource_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {
@@ -310,7 +310,7 @@ impl GraphicsCommandList {
 
     pub fn set_graphics_root_unordered_access_view(
         &self,
-        root_index: u32,
+        root_index: RootIndex,
         buffer_location: GpuAddress,
     ) {
         unsafe {

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -181,6 +181,20 @@ impl Factory4 {
     }
 }
 
+bitflags! {
+    pub struct SwapChainPresentFlags: u32 {
+        const DXGI_PRESENT_DO_NOT_SEQUENCE = dxgi::DXGI_PRESENT_DO_NOT_SEQUENCE;
+        const DXGI_PRESENT_TEST = dxgi::DXGI_PRESENT_TEST;
+        const DXGI_PRESENT_RESTART = dxgi::DXGI_PRESENT_RESTART;
+        const DXGI_PRESENT_DO_NOT_WAIT = dxgi::DXGI_PRESENT_DO_NOT_WAIT;
+        const DXGI_PRESENT_RESTRICT_TO_OUTPUT = dxgi::DXGI_PRESENT_RESTRICT_TO_OUTPUT;
+        const DXGI_PRESENT_STEREO_PREFER_RIGHT = dxgi::DXGI_PRESENT_STEREO_PREFER_RIGHT;
+        const DXGI_PRESENT_STEREO_TEMPORARY_MONO = dxgi::DXGI_PRESENT_STEREO_TEMPORARY_MONO;
+        const DXGI_PRESENT_USE_DURATION = dxgi::DXGI_PRESENT_USE_DURATION;
+        const DXGI_PRESENT_ALLOW_TEARING = dxgi::DXGI_PRESENT_ALLOW_TEARING;
+    }
+}
+
 impl SwapChain {
     pub fn get_buffer(&self, id: u32) -> D3DResult<Resource> {
         let mut resource = Resource::null();
@@ -190,9 +204,13 @@ impl SwapChain {
         (resource, hr)
     }
 
-    // TODO: present flags
+    //TODO: replace by present_flags
     pub fn present(&self, interval: u32, flags: u32) -> HRESULT {
         unsafe { self.Present(interval, flags) }
+    }
+
+    pub fn present_flags(&self, interval: u32, flags: SwapChainPresentFlags) -> HRESULT {
+        unsafe { self.Present(interval, flags.bits()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub type Format = dxgiformat::DXGI_FORMAT;
 pub type Rect = d3d12::D3D12_RECT;
 pub type NodeMask = u32;
 
+/// Index into the root signature.
+pub type RootIndex = u32;
 /// Draw vertex count.
 pub type VertexCount = u32;
 /// Draw vertex base offset.
@@ -74,9 +76,9 @@ pub enum FeatureLevel {
     L12_1 = d3dcommon::D3D_FEATURE_LEVEL_12_1,
 }
 
-pub type Blob = self::com::WeakPtr<d3dcommon::ID3DBlob>;
+pub type Blob = WeakPtr<d3dcommon::ID3DBlob>;
 
-pub type Error = self::com::WeakPtr<d3dcommon::ID3DBlob>;
+pub type Error = WeakPtr<d3dcommon::ID3DBlob>;
 impl Error {
     pub unsafe fn as_c_str(&self) -> &CStr {
         debug_assert!(!self.is_null());


### PR DESCRIPTION
Adding a new method like this is a bit wonky. We'd be better off just doing other breaking changes and releasing 0.4 properly, but I couldn't see any.
My plan was to have the lifetime for [RootParameter](https://github.com/gfx-rs/d3d12-rs/blob/2810498605f5757cdf66f769acdf15176e5eca3f/src/descriptor.rs#L91), but trying to update gfx DX12 backend for this ends up with much more headache than I hoped for, so I dropped this idea for now.