### PR TITLE
Version bump to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## Unreleased
+## v0.4.1 (2021-08-18)
   - expose all indirect argument types
+  - expose methods for setting root constants
 
 ## v0.4.0 (2021-04-29)
   - update `libloading` to 0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d3d12"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
 	"msiglreith <m.siglreith@gmail.com>",
 	"Dzmitry Malyshau <kvarkus@gmail.com>",


### PR DESCRIPTION
We need it on crates now. Fortunately, the changes weren't breaking.