### PR TITLE
Adds D3D11 DXGI Support and COM Helper Chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libloading = { version = "0.7", optional = true }
 
 [dependencies.winapi]
 version = "0.3"
-features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
+features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libloading = { version = "0.7", optional = true }
 
 [dependencies.winapi]
 version = "0.3"
-features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
+features = ["dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_5","dxgi1_6","dxgidebug","d3d12","d3d12sdklayers","d3dcommon","d3dcompiler","dxgiformat","synchapi","winerror"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/com.rs
+++ b/src/com.rs
@@ -31,8 +31,12 @@ impl<T> WeakPtr<T> {
         self.0
     }
 
-    pub unsafe fn mut_void(&mut self) -> *mut *mut c_void {
+    pub fn mut_void(&mut self) -> *mut *mut c_void {
         &mut self.0 as *mut *mut _ as *mut *mut _
+    }
+
+    pub fn mut_self(&mut self) -> *mut *mut T {
+        &mut self.0 as *mut *mut _
     }
 }
 

--- a/src/com.rs
+++ b/src/com.rs
@@ -216,12 +216,12 @@ macro_rules! weak_com_inheritance_chain {
         $variant:ident($type:ty);
         $($next_variant:ident),*;
     ) => {
-        #[doc = concat!("Construct this enum from weak pointer to a ", stringify!($type), ". For best usability, always use the highest constructor you can. This doesn't try to upcast.")]
+        // Construct this enum from weak pointer to this interface. For best usability, always use the highest constructor you can. This doesn't try to upcast.
         $vis unsafe fn $from_name(value: $crate::WeakPtr<$type>) -> Self {
             Self::$variant(value)
         }
 
-        #[doc = concat!("Returns Some if the value implements ", stringify!($type), " otherwise returns None.")]
+        // Returns Some if the value implements the interface otherwise returns None.
         $vis fn $as_name(&self) -> Option<&$crate::WeakPtr<$type>> {
             match *self {
                 $(
@@ -237,7 +237,7 @@ macro_rules! weak_com_inheritance_chain {
             }
         }
 
-        #[doc = concat!("Returns ", stringify!($type), " if the value implements it, otherwise panics.")]
+        // Returns the interface if the value implements it, otherwise panics.
         #[track_caller]
         $vis fn $unwrap_name(&self) -> &$crate::WeakPtr<$type> {
             match *self {

--- a/src/com.rs
+++ b/src/com.rs
@@ -114,10 +114,16 @@ impl<T> Hash for WeakPtr<T> {
 /// - the as function (`&self -> Option<WeakPtr<actual::ComObject1>>`)
 /// - the unwrap function (`&self -> WeakPtr<actual::ComObject1>` panicing on failure to cast)
 ///
-/// ```no_compile,rust
+/// ```rust
+/// # pub use d3d12::weak_com_inheritance_chain;
+/// # mod actual { 
+/// #     pub struct ComObject; impl winapi::Interface for ComObject { fn uuidof() -> winapi::shared::guiddef::GUID { todo!() } } 
+/// #     pub struct ComObject1; impl winapi::Interface for ComObject1 { fn uuidof() -> winapi::shared::guiddef::GUID { todo!() } }
+/// #     pub struct ComObject2; impl winapi::Interface for ComObject2 { fn uuidof() -> winapi::shared::guiddef::GUID { todo!() } }
+/// # }
 /// weak_com_inheritance_chain! {
 ///     pub enum MyComObject {
-///         MyComObject(actual::ComObject), from_my_com_object; as_my_com_object, my_com_object; // First variant doesn't use "unwrap" as it can never fail
+///         MyComObject(actual::ComObject), from_my_com_object, as_my_com_object, my_com_object; // First variant doesn't use "unwrap" as it can never fail
 ///         MyComObject1(actual::ComObject1), from_my_com_object1, as_my_com_object1, unwrap_my_com_object1;
 ///         MyComObject2(actual::ComObject2), from_my_com_object2, as_my_com_object2, unwrap_my_com_object2;
 ///     }

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -156,6 +156,7 @@ impl RootParameter {
 impl fmt::Debug for RootParameter {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         #[derive(Debug)]
+        #[allow(dead_code)] // False-positive
         enum Inner<'a> {
             Table(&'a [DescriptorRange]),
             Constants { binding: Binding, num: u32 },

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -2,7 +2,7 @@ use crate::{com::WeakPtr, D3DResult, Resource, SampleDesc, HRESULT};
 use std::ptr;
 use winapi::{
     shared::{
-        dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_6, dxgiformat, dxgitype, minwindef::TRUE,
+        dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, dxgi1_6, dxgiformat, dxgitype, minwindef::TRUE,
         windef::HWND,
     },
     um::{d3d12, dxgidebug, unknwnbase::IUnknown},
@@ -45,12 +45,36 @@ pub enum AlphaMode {
 pub type Adapter1 = WeakPtr<dxgi::IDXGIAdapter1>;
 pub type Factory1 = WeakPtr<dxgi::IDXGIFactory1>;
 pub type Factory2 = WeakPtr<dxgi1_2::IDXGIFactory2>;
+pub type Factory3 = WeakPtr<dxgi1_3::IDXGIFactory3>;
 pub type Factory4 = WeakPtr<dxgi1_4::IDXGIFactory4>;
+pub type Factory5 = WeakPtr<dxgi1_5::IDXGIFactory5>;
 pub type Factory6 = WeakPtr<dxgi1_6::IDXGIFactory6>;
 pub type InfoQueue = WeakPtr<dxgidebug::IDXGIInfoQueue>;
 pub type SwapChain = WeakPtr<dxgi::IDXGISwapChain>;
 pub type SwapChain1 = WeakPtr<dxgi1_2::IDXGISwapChain1>;
 pub type SwapChain3 = WeakPtr<dxgi1_4::IDXGISwapChain3>;
+
+crate::weak_com_inheritance_chain! {
+    #[derive(Debug, Copy, Clone, PartialEq, Hash)]
+    pub enum DxgiFactory {
+        Factory1(dxgi::IDXGIFactory1), from_factory1, as_factory1, unwrap_factory1;
+        Factory2(dxgi1_2::IDXGIFactory2), from_factory2, as_factory2, unwrap_factory2;
+        Factory3(dxgi1_3::IDXGIFactory3), from_factory3, as_factory3, unwrap_factory3;
+        Factory4(dxgi1_4::IDXGIFactory4), from_factory4, as_factory4, unwrap_factory4;
+        Factory5(dxgi1_5::IDXGIFactory5), from_factory5, as_factory5, unwrap_factory5;
+        Factory6(dxgi1_6::IDXGIFactory6), from_factory6, as_factory6, unwrap_factory6;
+    }
+}
+
+crate::weak_com_inheritance_chain! {
+    #[derive(Debug, Copy, Clone, PartialEq, Hash)]
+    pub enum DxgiSwapchain {
+        SwapChain(dxgi::IDXGISwapChain), from_swap_chain, as_swap_chain, unwrap_swap_chain;
+        SwapChain1(dxgi1_2::IDXGISwapChain1), from_swap_chain1, as_swap_chain1, unwrap_swap_chain1;
+        SwapChain2(dxgi1_3::IDXGISwapChain2), from_swap_chain2, as_swap_chain2, unwrap_swap_chain2;
+        SwapChain3(dxgi1_4::IDXGISwapChain3), from_swap_chain3, as_swap_chain3, unwrap_swap_chain3;
+    }
+}
 
 #[cfg(feature = "libloading")]
 #[derive(Debug)]
@@ -249,10 +273,6 @@ impl Factory4 {
         (factory, hr)
     }
 
-    pub fn as_factory2(&self) -> Factory2 {
-        unsafe { Factory2::from_raw(self.as_mut_ptr() as *mut _) }
-    }
-
     pub fn enumerate_adapters(&self, id: u32) -> D3DResult<Adapter1> {
         let mut adapter = Adapter1::null();
         let hr = unsafe { self.EnumAdapters1(id, adapter.mut_void() as *mut *mut _) };
@@ -294,17 +314,7 @@ impl SwapChain {
     }
 }
 
-impl SwapChain1 {
-    pub fn as_swapchain0(&self) -> SwapChain {
-        unsafe { SwapChain::from_raw(self.as_mut_ptr() as *mut _) }
-    }
-}
-
 impl SwapChain3 {
-    pub fn as_swapchain0(&self) -> SwapChain {
-        unsafe { SwapChain::from_raw(self.as_mut_ptr() as *mut _) }
-    }
-
     pub fn get_current_back_buffer_index(&self) -> u32 {
         unsafe { self.GetCurrentBackBufferIndex() }
     }

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -51,7 +51,7 @@ pub type Adapter4 = WeakPtr<dxgi1_6::IDXGIAdapter4>;
 crate::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq, Hash)]
     pub enum DxgiAdapter {
-        Adapter1(dxgi::IDXGIAdapter1), from_adapter1, as_adapter1, unwrap_adapter1;
+        Adapter1(dxgi::IDXGIAdapter1), from_adapter1, as_adapter1, adapter1;
         Adapter2(dxgi1_2::IDXGIAdapter2), from_adapter2, as_adapter2, unwrap_adapter2;
         Adapter3(dxgi1_4::IDXGIAdapter3), from_adapter3, as_adapter3, unwrap_adapter3;
         Adapter4(dxgi1_6::IDXGIAdapter4), from_adapter4, as_adapter4, unwrap_adapter4;
@@ -67,7 +67,7 @@ pub type Factory6 = WeakPtr<dxgi1_6::IDXGIFactory6>;
 crate::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq, Hash)]
     pub enum DxgiFactory {
-        Factory1(dxgi::IDXGIFactory1), from_factory1, as_factory1, unwrap_factory1;
+        Factory1(dxgi::IDXGIFactory1), from_factory1, as_factory1, factory1;
         Factory2(dxgi1_2::IDXGIFactory2), from_factory2, as_factory2, unwrap_factory2;
         Factory3(dxgi1_3::IDXGIFactory3), from_factory3, as_factory3, unwrap_factory3;
         Factory4(dxgi1_4::IDXGIFactory4), from_factory4, as_factory4, unwrap_factory4;
@@ -83,7 +83,7 @@ pub type SwapChain3 = WeakPtr<dxgi1_4::IDXGISwapChain3>;
 crate::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq, Hash)]
     pub enum DxgiSwapchain {
-        SwapChain(dxgi::IDXGISwapChain), from_swap_chain, as_swap_chain, unwrap_swap_chain;
+        SwapChain(dxgi::IDXGISwapChain), from_swap_chain, as_swap_chain, swap_chain;
         SwapChain1(dxgi1_2::IDXGISwapChain1), from_swap_chain1, as_swap_chain1, unwrap_swap_chain1;
         SwapChain2(dxgi1_3::IDXGISwapChain2), from_swap_chain2, as_swap_chain2, unwrap_swap_chain2;
         SwapChain3(dxgi1_4::IDXGISwapChain3), from_swap_chain3, as_swap_chain3, unwrap_swap_chain3;

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -2,7 +2,8 @@ use crate::{com::WeakPtr, D3DResult, Resource, SampleDesc, HRESULT};
 use std::ptr;
 use winapi::{
     shared::{
-        dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgiformat, dxgitype, minwindef::TRUE, windef::HWND,
+        dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_6, dxgiformat, dxgitype, minwindef::TRUE,
+        windef::HWND,
     },
     um::{d3d12, dxgidebug, unknwnbase::IUnknown},
     Interface,
@@ -45,6 +46,7 @@ pub type Adapter1 = WeakPtr<dxgi::IDXGIAdapter1>;
 pub type Factory1 = WeakPtr<dxgi::IDXGIFactory1>;
 pub type Factory2 = WeakPtr<dxgi1_2::IDXGIFactory2>;
 pub type Factory4 = WeakPtr<dxgi1_4::IDXGIFactory4>;
+pub type Factory6 = WeakPtr<dxgi1_6::IDXGIFactory6>;
 pub type InfoQueue = WeakPtr<dxgidebug::IDXGIInfoQueue>;
 pub type SwapChain = WeakPtr<dxgi::IDXGISwapChain>;
 pub type SwapChain1 = WeakPtr<dxgi1_2::IDXGISwapChain1>;

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -42,18 +42,28 @@ pub enum AlphaMode {
     ForceDword = dxgi1_2::DXGI_ALPHA_MODE_FORCE_DWORD,
 }
 
+pub type InfoQueue = WeakPtr<dxgidebug::IDXGIInfoQueue>;
+
 pub type Adapter1 = WeakPtr<dxgi::IDXGIAdapter1>;
+pub type Adapter2 = WeakPtr<dxgi1_2::IDXGIAdapter2>;
+pub type Adapter3 = WeakPtr<dxgi1_4::IDXGIAdapter3>;
+pub type Adapter4 = WeakPtr<dxgi1_6::IDXGIAdapter4>;
+crate::weak_com_inheritance_chain! {
+    #[derive(Debug, Copy, Clone, PartialEq, Hash)]
+    pub enum DxgiAdapter {
+        Adapter1(dxgi::IDXGIAdapter1), from_adapter1, as_adapter1, unwrap_adapter1;
+        Adapter2(dxgi1_2::IDXGIAdapter2), from_adapter2, as_adapter2, unwrap_adapter2;
+        Adapter3(dxgi1_4::IDXGIAdapter3), from_adapter3, as_adapter3, unwrap_adapter3;
+        Adapter4(dxgi1_6::IDXGIAdapter4), from_adapter4, as_adapter4, unwrap_adapter4;
+    }
+}
+
 pub type Factory1 = WeakPtr<dxgi::IDXGIFactory1>;
 pub type Factory2 = WeakPtr<dxgi1_2::IDXGIFactory2>;
 pub type Factory3 = WeakPtr<dxgi1_3::IDXGIFactory3>;
 pub type Factory4 = WeakPtr<dxgi1_4::IDXGIFactory4>;
 pub type Factory5 = WeakPtr<dxgi1_5::IDXGIFactory5>;
 pub type Factory6 = WeakPtr<dxgi1_6::IDXGIFactory6>;
-pub type InfoQueue = WeakPtr<dxgidebug::IDXGIInfoQueue>;
-pub type SwapChain = WeakPtr<dxgi::IDXGISwapChain>;
-pub type SwapChain1 = WeakPtr<dxgi1_2::IDXGISwapChain1>;
-pub type SwapChain3 = WeakPtr<dxgi1_4::IDXGISwapChain3>;
-
 crate::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq, Hash)]
     pub enum DxgiFactory {
@@ -66,6 +76,10 @@ crate::weak_com_inheritance_chain! {
     }
 }
 
+pub type SwapChain = WeakPtr<dxgi::IDXGISwapChain>;
+pub type SwapChain1 = WeakPtr<dxgi1_2::IDXGISwapChain1>;
+pub type SwapChain2 = WeakPtr<dxgi1_3::IDXGISwapChain2>;
+pub type SwapChain3 = WeakPtr<dxgi1_4::IDXGISwapChain3>;
 crate::weak_com_inheritance_chain! {
     #[derive(Debug, Copy, Clone, PartialEq, Hash)]
     pub enum DxgiSwapchain {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub struct SampleDesc {
 }
 
 #[repr(u32)]
+#[non_exhaustive]
 pub enum FeatureLevel {
     L9_1 = d3dcommon::D3D_FEATURE_LEVEL_9_1,
     L9_2 = d3dcommon::D3D_FEATURE_LEVEL_9_2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate bitflags;
 
-use std::ffi::CStr;
+use std::{convert::TryFrom, ffi::CStr};
 use winapi::{
     shared::dxgiformat,
     um::{d3d12, d3dcommon},
@@ -74,6 +74,25 @@ pub enum FeatureLevel {
     L11_1 = d3dcommon::D3D_FEATURE_LEVEL_11_1,
     L12_0 = d3dcommon::D3D_FEATURE_LEVEL_12_0,
     L12_1 = d3dcommon::D3D_FEATURE_LEVEL_12_1,
+}
+
+impl TryFrom<u32> for FeatureLevel {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            d3dcommon::D3D_FEATURE_LEVEL_9_1 => Self::L9_1,
+            d3dcommon::D3D_FEATURE_LEVEL_9_2 => Self::L9_2,
+            d3dcommon::D3D_FEATURE_LEVEL_9_3 => Self::L9_3,
+            d3dcommon::D3D_FEATURE_LEVEL_10_0 => Self::L10_0,
+            d3dcommon::D3D_FEATURE_LEVEL_10_1 => Self::L10_1,
+            d3dcommon::D3D_FEATURE_LEVEL_11_0 => Self::L11_0,
+            d3dcommon::D3D_FEATURE_LEVEL_11_1 => Self::L11_1,
+            d3dcommon::D3D_FEATURE_LEVEL_12_0 => Self::L12_0,
+            d3dcommon::D3D_FEATURE_LEVEL_12_1 => Self::L12_1,
+            _ => return Err(()),
+        })
+    }
 }
 
 pub type Blob = WeakPtr<d3dcommon::ID3DBlob>;


### PR DESCRIPTION
This PR should be squashed and reviewed as a whole.

This adds a variety of helpers for dxgi dx11 support, as well as adding a COM macro to help deal with COM inheritance chain. I would like to roll out this macro throughout dx12 eventually, but I'm going to start with the DXGI code and the DX11 code as proof of it being useful.