### PR TITLE
Bump `libloading` to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ implicit-link = []
 
 [dependencies]
 bitflags = "2"
-libloading = { version = "0.7", optional = true }
+# libloading 0.8 switches from `winapi` to `windows-sys`; permit either
+libloading = { version = ">=0.7,<0.9", optional = true }
 
 [dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
The only relevant change is the migration to `windows-sys`: https://docs.rs/libloading/0.8.0/libloading/changelog/r0_8_0/index.html.

This is done in the same spirit as https://github.com/gfx-rs/wgpu/pull/3711 because I heard Mozilla isn't ready to migrate to `windows-sys` yet.