### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 implicit-link = []
 
 [dependencies]
-bitflags = "1"
+bitflags = "2"
 libloading = { version = "0.7", optional = true }
 
 [dependencies.winapi]

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -20,6 +20,7 @@ pub enum CmdListType {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct ClearFlags: u32 {
         const DEPTH = d3d12::D3D12_CLEAR_FLAG_DEPTH;
         const STENCIL = d3d12::D3D12_CLEAR_FLAG_STENCIL;

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -21,6 +21,7 @@ pub enum DescriptorHeapType {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct DescriptorHeapFlags: u32 {
         const SHADER_VISIBLE = d3d12::D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     }
@@ -253,6 +254,7 @@ pub enum RootSignatureVersion {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct RootSignatureFlags: u32 {
         const ALLOW_IA_INPUT_LAYOUT = d3d12::D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
         const DENY_VS_ROOT_ACCESS = d3d12::D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS;

--- a/src/dxgi.rs
+++ b/src/dxgi.rs
@@ -10,6 +10,7 @@ use winapi::{
 };
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct FactoryCreationFlags: u32 {
         const DEBUG = dxgi1_3::DXGI_CREATE_FACTORY_DEBUG;
     }
@@ -336,6 +337,7 @@ impl FactoryMedia {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct SwapChainPresentFlags: u32 {
         const DXGI_PRESENT_DO_NOT_SEQUENCE = dxgi::DXGI_PRESENT_DO_NOT_SEQUENCE;
         const DXGI_PRESENT_TEST = dxgi::DXGI_PRESENT_TEST;

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -30,6 +30,7 @@ pub enum MemoryPool {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct HeapFlags: u32 {
         const NONE = d3d12::D3D12_HEAP_FLAG_NONE;
         const SHARED = d3d12::D3D12_HEAP_FLAG_SHARED;

--- a/src/pso.rs
+++ b/src/pso.rs
@@ -5,12 +5,14 @@ use std::{ffi, ops::Deref, ptr};
 use winapi::um::{d3d12, d3dcompiler};
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct PipelineStateFlags: u32 {
         const TOOL_DEBUG = d3d12::D3D12_PIPELINE_STATE_FLAG_TOOL_DEBUG;
     }
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct ShaderCompileFlags: u32 {
         const DEBUG = d3dcompiler::D3DCOMPILE_DEBUG;
         const SKIP_VALIDATION = d3dcompiler::D3DCOMPILE_SKIP_VALIDATION;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -9,6 +9,7 @@ pub enum Priority {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct CommandQueueFlags: u32 {
         const DISABLE_GPU_TIMEOUT = d3d12::D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
     }


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

I was a bit liberal with deriving `std` traits on public types, which mimics the behavior of `bitflags` v1, let me know if we don't need all these traits. Potentially we could at least drop `PartialOrd` and `Ord`.